### PR TITLE
Update 스테이지에 따른 아이템 생성

### DIFF
--- a/assets/item_unlock.json
+++ b/assets/item_unlock.json
@@ -2,7 +2,11 @@
   "name": "item_unlock",
   "version": "1.0.0",
   "data": [
-    { "id":  101, "stage_id": 1001, "item_id": 1 },
-    { "id":  201, "stage_id": 1002, "item_id": 2 }
+    { "id": 101, "stage_id": 1001, "item_id": [1] },
+    { "id": 201, "stage_id": 1002, "item_id": [1, 2] },
+    { "id": 301, "stage_id": 1003, "item_id": [1, 2, 3] },
+    { "id": 401, "stage_id": 1004, "item_id": [1, 2, 3, 4] },
+    { "id": 501, "stage_id": 1005, "item_id": [1, 2, 3, 4, 5] },
+    { "id": 601, "stage_id": 1006, "item_id": [1, 2, 3, 4, 5, 6] }
   ]
 }

--- a/public/ItemController.js
+++ b/public/ItemController.js
@@ -30,11 +30,19 @@ class ItemController {
     // item_unlock.json의 데이터 테이블 item_id
     const itemId = item_unlock.data[stageLevel].item_id;
 
+    // 생성 가능한 아이템 id 목록 출력
+    console.log(itemId);
+
     //const index = this.getRandomNumber(0, this.itemImages.length - 1);
     // item_id의 index중 하나를 랜덤으로 가져옴
     const index = this.getRandomNumber(0, itemId.length - 1);
     // index의 item_id의 값 할당
-    const itemInfo = this.itemImages[itemId[index]];
+    const itemInfo = this.itemImages[itemId[index] - 1];
+
+    // 아이템 id 및 이미지 내용 출력
+    console.log(`item id : ${itemId[index]}`);
+    console.log(itemInfo.image);
+
     const x = this.canvas.width * 1.5;
     const y = this.getRandomNumber(10, this.canvas.height - itemInfo.height);
 

--- a/public/ItemController.js
+++ b/public/ItemController.js
@@ -1,90 +1,88 @@
-import Item from "./Item.js";
+import Item from './Item.js';
+import item_unlock from './assets/item_unlock.json' with { type: 'json' };
 
 class ItemController {
+  INTERVAL_MIN = 0;
+  INTERVAL_MAX = 12000;
 
-    INTERVAL_MIN = 0;
-    INTERVAL_MAX = 12000;
+  nextInterval = null;
+  items = [];
 
-    nextInterval = null;
-    items = [];
+  constructor(ctx, itemImages, scaleRatio, speed) {
+    this.ctx = ctx;
+    this.canvas = ctx.canvas;
+    this.itemImages = itemImages;
+    this.scaleRatio = scaleRatio;
+    this.speed = speed;
 
+    this.setNextItemTime();
+  }
 
-    constructor(ctx, itemImages, scaleRatio, speed) {
-        this.ctx = ctx;
-        this.canvas = ctx.canvas;
-        this.itemImages = itemImages;
-        this.scaleRatio = scaleRatio;
-        this.speed = speed;
+  setNextItemTime() {
+    this.nextInterval = this.getRandomNumber(this.INTERVAL_MIN, this.INTERVAL_MAX);
+  }
 
-        this.setNextItemTime();
+  getRandomNumber(min, max) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+  }
+
+  createItem(stageLevel) {
+    // item_unlock.json의 데이터 테이블 item_id
+    const itemId = item_unlock.data[stageLevel].item_id;
+
+    //const index = this.getRandomNumber(0, this.itemImages.length - 1);
+    // item_id의 index중 하나를 랜덤으로 가져옴
+    const index = this.getRandomNumber(0, itemId.length - 1);
+    // index의 item_id의 값 할당
+    const itemInfo = this.itemImages[itemId[index]];
+    const x = this.canvas.width * 1.5;
+    const y = this.getRandomNumber(10, this.canvas.height - itemInfo.height);
+
+    const item = new Item(
+      this.ctx,
+      itemInfo.id,
+      x,
+      y,
+      itemInfo.width,
+      itemInfo.height,
+      itemInfo.image,
+    );
+
+    this.items.push(item);
+  }
+
+  update(gameSpeed, deltaTime, stageLevel) {
+    if (this.nextInterval <= 0) {
+      this.createItem(stageLevel);
+      this.setNextItemTime();
     }
 
-    setNextItemTime() {
-        this.nextInterval = this.getRandomNumber(
-            this.INTERVAL_MIN,
-            this.INTERVAL_MAX
-        );
+    this.nextInterval -= deltaTime;
+
+    this.items.forEach((item) => {
+      item.update(this.speed, gameSpeed, deltaTime, this.scaleRatio);
+    });
+
+    this.items = this.items.filter((item) => item.x > -item.width);
+  }
+
+  draw() {
+    this.items.forEach((item) => item.draw());
+  }
+
+  collideWith(sprite) {
+    const collidedItem = this.items.find((item) => item.collideWith(sprite));
+    if (collidedItem) {
+      this.ctx.clearRect(collidedItem.x, collidedItem.y, collidedItem.width, collidedItem.height);
+      return {
+        itemId: collidedItem.id,
+      };
     }
+  }
 
-    getRandomNumber(min, max) {
-        return Math.floor(Math.random() * (max - min + 1) + min);
-    }
-
-    createItem() {
-        const index = this.getRandomNumber(0, this.itemImages.length - 1);
-        const itemInfo = this.itemImages[index];
-        const x = this.canvas.width * 1.5;
-        const y = this.getRandomNumber(
-            10,
-            this.canvas.height - itemInfo.height
-        );
-
-        const item = new Item(
-            this.ctx,
-            itemInfo.id,
-            x,
-            y,
-            itemInfo.width,
-            itemInfo.height,
-            itemInfo.image
-        );
-
-        this.items.push(item);
-    }
-
-
-    update(gameSpeed, deltaTime) {
-        if(this.nextInterval <= 0) {
-            this.createItem();
-            this.setNextItemTime();
-        }
-
-        this.nextInterval -= deltaTime;
-
-        this.items.forEach((item) => {
-            item.update(this.speed, gameSpeed, deltaTime, this.scaleRatio);
-        })
-
-        this.items = this.items.filter(item => item.x > -item.width);
-    }
-
-    draw() {
-        this.items.forEach((item) => item.draw());
-    }
-
-    collideWith(sprite) {
-        const collidedItem = this.items.find(item => item.collideWith(sprite))
-        if (collidedItem) {
-            this.ctx.clearRect(collidedItem.x, collidedItem.y, collidedItem.width, collidedItem.height)
-            return {
-                itemId: collidedItem.id
-            }
-        }
-    }
-
-    reset() {
-        this.items = [];
-    }
+  reset() {
+    this.items = [];
+  }
 }
 
 export default ItemController;

--- a/public/Score.js
+++ b/public/Score.js
@@ -73,6 +73,11 @@ class Score {
     }
   }
 
+  // 현재 스테이지 레벨 리턴
+  getStageLevel() {
+    return this.stageLevel;
+  }
+
   getItem(itemId) {
     // 아이템 획득시 점수 변화
     this.score += 0;

--- a/public/Score.js
+++ b/public/Score.js
@@ -68,7 +68,6 @@ class Score {
       console.log('get in 60 score loop');
       this.stageChange6 = false;
       sendEvent(11, { currentStage: 1005, targetStage: 1006 });
-      this.stageLevel++;
       console.log(`scorePerSecond : ${this.scorePerSecond}`);
     }
   }

--- a/public/assets/item_unlock.json
+++ b/public/assets/item_unlock.json
@@ -2,7 +2,11 @@
   "name": "item_unlock",
   "version": "1.0.0",
   "data": [
-    { "id":  101, "stage_id": 1001, "item_id": 1 },
-    { "id":  201, "stage_id": 1002, "item_id": 2 }
+    { "id": 101, "stage_id": 1001, "item_id": [1] },
+    { "id": 201, "stage_id": 1002, "item_id": [1, 2] },
+    { "id": 301, "stage_id": 1003, "item_id": [1, 2, 3] },
+    { "id": 401, "stage_id": 1004, "item_id": [1, 2, 3, 4] },
+    { "id": 501, "stage_id": 1005, "item_id": [1, 2, 3, 4, 5] },
+    { "id": 601, "stage_id": 1006, "item_id": [1, 2, 3, 4, 5, 6] }
   ]
 }

--- a/public/index.js
+++ b/public/index.js
@@ -42,6 +42,8 @@ const ITEM_CONFIG = [
   { width: 50 / 1.5, height: 50 / 1.5, id: 2, image: 'images/items/pokeball_yellow.png' },
   { width: 50 / 1.5, height: 50 / 1.5, id: 3, image: 'images/items/pokeball_purple.png' },
   { width: 50 / 1.5, height: 50 / 1.5, id: 4, image: 'images/items/pokeball_cyan.png' },
+  { width: 50 / 1.5, height: 50 / 1.5, id: 5, image: 'images/items/pokeball_orange.png' },
+  { width: 50 / 1.5, height: 50 / 1.5, id: 6, image: 'images/items/pokeball_pink.png' },
 ];
 
 // 게임 요소들
@@ -205,7 +207,13 @@ function gameLoop(currentTime) {
     ground.update(gameSpeed, deltaTime);
     // 선인장
     cactiController.update(gameSpeed, deltaTime);
-    itemController.update(gameSpeed, deltaTime);
+
+    // 현재 스테이지
+    const stageLevel = score.getStageLevel();
+
+    // 아이템
+    itemController.update(gameSpeed, deltaTime, stageLevel);
+
     // 달리기
     player.update(gameSpeed, deltaTime);
     updateGameSpeed(deltaTime);

--- a/public/index.js
+++ b/public/index.js
@@ -39,10 +39,10 @@ const CACTI_CONFIG = [
 // 아이템
 const ITEM_CONFIG = [
   { width: 50 / 1.5, height: 50 / 1.5, id: 1, image: 'images/items/pokeball_red.png' },
-  { width: 50 / 1.5, height: 50 / 1.5, id: 2, image: 'images/items/pokeball_yellow.png' },
-  { width: 50 / 1.5, height: 50 / 1.5, id: 3, image: 'images/items/pokeball_purple.png' },
+  { width: 50 / 1.5, height: 50 / 1.5, id: 2, image: 'images/items/pokeball_orange.png' },
+  { width: 50 / 1.5, height: 50 / 1.5, id: 3, image: 'images/items/pokeball_yellow.png' },
   { width: 50 / 1.5, height: 50 / 1.5, id: 4, image: 'images/items/pokeball_cyan.png' },
-  { width: 50 / 1.5, height: 50 / 1.5, id: 5, image: 'images/items/pokeball_orange.png' },
+  { width: 50 / 1.5, height: 50 / 1.5, id: 5, image: 'images/items/pokeball_purple.png' },
   { width: 50 / 1.5, height: 50 / 1.5, id: 6, image: 'images/items/pokeball_pink.png' },
 ];
 


### PR DESCRIPTION
### 스테이지에 따른 아이템 생성

- 스테이지에 따라 생성되는 아이템이 구분되어야 함
    - 1 스테이지 ⇒ 1번 아이템,  1가지 생성
    - 2 스테이지 ⇒ 1, 2번 아이템,  2가지 종류가 생성
    - 3 스테이지 ⇒ 1, 2, 3번 아이템, 3가지 종류가 생성
    - 4 스테이지 ⇒ 1, 2, 3, 4번 아이템, 4가지 종류가 생성
    - 5 스테이지 ⇒ 1, 2, 3, 4, 5번 아이템, 5가지 종류가 생성
    - 6 스테이지 ⇒ 1, 2, 3, 4, 5, 6번 아이템, 6가지 종류가 생성
- 이 기능도 ‘2’번의 기능과 마찬가지로 데이터 테이블 활용
  - 현재 만들어져 있는 ‘item.json’ 과 ‘item_unlock.json’ 2가지 데이터 테이블 활용

### 아이템 생성 [ 0스테이지 ~ 5스테이지 ]

![아이템 생성-1](https://github.com/eliotjang/websocket-real-time-game/assets/37320831/63381fca-c8d3-403d-8f85-5e875b1ffd1f)


### 아이템 생성 [ 6스테이지 이후 ]

![아이템 생성-2](https://github.com/eliotjang/websocket-real-time-game/assets/37320831/579830a6-cc50-413a-a943-fae3a9c75c82)

