### PR TITLE
Update 아이템 별 획득 점수 구분

### DIFF
--- a/public/Score.js
+++ b/public/Score.js
@@ -12,6 +12,7 @@ class Score {
   stageChange5 = true;
   stageChange6 = true;
   stageLevel = 0;
+  stageId = 1001;
   scorePerSecond = 1;
 
   constructor(ctx, scaleRatio) {
@@ -22,51 +23,56 @@ class Score {
 
   update(deltaTime) {
     this.scorePerSecond = stages.data[this.stageLevel].scorePerSecond;
-
     this.score += deltaTime * 0.001 * this.scorePerSecond;
-    // 점수가 10점 이상이 될 시 서버에 메시지 전송
-    if (Math.floor(this.score) >= 10 && this.stageChange1) {
-      console.log('get in 10 score loop');
+
+    // 점수가 100점 이상이 될 시 서버에 메시지 전송
+    if (Math.floor(this.score) >= 100 && this.stageChange1) {
+      console.log('[Stage 1] get in 100 score!');
       this.stageChange1 = false;
       sendEvent(11, { currentStage: 1000, targetStage: 1001 });
       this.stageLevel++;
+      this.stageId++;
       console.log(`scorePerSecond : ${this.scorePerSecond}`);
     }
-    // 점수가 20점 이상이 될 시 서버에 메시지 전송
-    if (Math.floor(this.score) >= 20 && this.stageChange2) {
-      console.log('get in 20 score loop');
+    // 점수가 200점 이상이 될 시 서버에 메시지 전송
+    if (Math.floor(this.score) >= 200 && this.stageChange2) {
+      console.log('[Stage 2] get in 200 score!');
       this.stageChange2 = false;
       sendEvent(11, { currentStage: 1001, targetStage: 1002 });
       this.stageLevel++;
+      this.stageId++;
       console.log(`scorePerSecond : ${this.scorePerSecond}`);
     }
-    // 점수가 30점 이상이 될 시 서버에 메시지 전송
-    if (Math.floor(this.score) >= 30 && this.stageChange3) {
-      console.log('get in 30 score loop');
+    // 점수가 300점 이상이 될 시 서버에 메시지 전송
+    if (Math.floor(this.score) >= 300 && this.stageChange3) {
+      console.log('[Stage 3] get in 300 score!');
       this.stageChange3 = false;
       sendEvent(11, { currentStage: 1002, targetStage: 1003 });
       this.stageLevel++;
+      this.stageId++;
       console.log(`scorePerSecond : ${this.scorePerSecond}`);
     }
-    // 점수가 40점 이상이 될 시 서버에 메시지 전송
-    if (Math.floor(this.score) >= 40 && this.stageChange4) {
-      console.log('get in 40 score loop');
+    // 점수가 400점 이상이 될 시 서버에 메시지 전송
+    if (Math.floor(this.score) >= 400 && this.stageChange4) {
+      console.log('[Stage 4] get in 400 score!');
       this.stageChange4 = false;
       sendEvent(11, { currentStage: 1003, targetStage: 1004 });
       this.stageLevel++;
+      this.stageId++;
       console.log(`scorePerSecond : ${this.scorePerSecond}`);
     }
-    // 점수가 50점 이상이 될 시 서버에 메시지 전송
-    if (Math.floor(this.score) >= 50 && this.stageChange5) {
-      console.log('get in 50 score loop');
+    // 점수가 500점 이상이 될 시 서버에 메시지 전송
+    if (Math.floor(this.score) >= 500 && this.stageChange5) {
+      console.log('[Stage 5] get in 500 score!');
       this.stageChange5 = false;
       sendEvent(11, { currentStage: 1004, targetStage: 1005 });
       this.stageLevel++;
+      this.stageId++;
       console.log(`scorePerSecond : ${this.scorePerSecond}`);
     }
-    // 점수가 60점 이상이 될 시 서버에 메시지 전송
-    if (Math.floor(this.score) >= 60 && this.stageChange6) {
-      console.log('get in 60 score loop');
+    // 점수가 600점 이상이 될 시 서버에 메시지 전송
+    if (Math.floor(this.score) >= 600 && this.stageChange6) {
+      console.log('[Stage 6] get in 600 score!');
       this.stageChange6 = false;
       sendEvent(11, { currentStage: 1005, targetStage: 1006 });
       console.log(`scorePerSecond : ${this.scorePerSecond}`);
@@ -79,19 +85,19 @@ class Score {
   }
 
   getItem(itemId) {
-    // 아이템 획득시 점수 변화
+    // 현재 점수에 아이템 획득 점수 추가
+    const index = items.data.findIndex((e) => e.id === itemId);
     console.log(`before get item Score : ${this.score}`);
-    this.score += 10;
+    this.score += items.data[index].score;
     console.log(`after get item Score : ${this.score}`);
 
-    // 5. Update 아이템 별 획득 점수 구분 시 추가 로직
-    // 아이템 id와 점수 출력
-    // console.log(`itemId : ${itemId}, itemScore : ${items.data[index].score}`);
-
-    // 현재 점수에 아이템 획득 점수 추가
-    // console.log(`before get item Score : ${this.score}`);
-    // this.score += items.data[index].score;
-    // console.log(`after get item Score : ${this.score}`);
+    // 아이템 획득 시 서버에 메시지 전송
+    sendEvent(21, {
+      itemId,
+      score: items.data[index].score,
+      stageId: this.stageId,
+      timestamp: Date.now(),
+    });
   }
 
   reset() {

--- a/public/index.js
+++ b/public/index.js
@@ -5,7 +5,6 @@ import Score from './Score.js';
 import ItemController from './ItemController.js';
 import './Socket.js';
 import { sendEvent } from './Socket.js';
-//import { getGameAssets } from '../src/init/assets.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -232,9 +231,6 @@ function gameLoop(currentTime) {
   const collideWithItem = itemController.collideWith(player);
   if (collideWithItem && collideWithItem.itemId) {
     score.getItem(collideWithItem.itemId);
-
-    // 아이템 획득 시 서버에 메시지 전송
-    sendEvent(21, { itemId: collideWithItem.itemId, timestamp: Date.now() });
   }
 
   // draw

--- a/src/handlers/item.handler.js
+++ b/src/handlers/item.handler.js
@@ -3,32 +3,43 @@ import { getGameAssets } from '../init/assets.js';
 const INTERVAL_MIN = 5;
 let getItemTime = null;
 
-// 아이템 생성 시간 검증
+// 아이템 획득 검증
 export const acquireItemHandler = (userId, payload) => {
-  const { items } = getGameAssets();
+  const { items, itemUnlocks } = getGameAssets();
 
-  const { itemId, timestamp } = payload;
+  const { itemId, score, stageId, timestamp } = payload;
 
-  // 처음 아이템 획득 시, 아이템 검증 시작
-  if (!getItemTime) {
-    getItemTime = timestamp;
-    return { status: 'success', message: 'begin item verification' };
+  // 아이템 종류 별 획득 점수 계산
+  const index = items.data.findIndex((e) => e.id === itemId);
+  // 클라이언트에서 받은 점수와 서버에서 확인 점수가 다를 시, 아이템 획득 점수 인증 실패 메시지 반환
+  if (score !== items.data[index].score) {
+    return { status: 'fail', message: 'item score verification failed' };
   }
 
-  const index = items.data.findIndex((e) => e.id === itemId);
-  const responseTime = items.data[index].responseTime;
+  // 아이템 종류 별 획득 스테이지 검증
+  const unlockIndex = itemUnlocks.data.findIndex((e) => e.stage_id === stageId);
+  // 클라이언트에서 받은 아이템 ID가 서버에서 스테이지에 맞는 해금 아이템이 들어오지 않은 경우, 실패 메시지 반환
+  if (!itemUnlocks.data[unlockIndex].item_id.includes(itemId)) {
+    return { status: 'fail', message: 'item unlock stage verification failed' };
+  }
+
+  // 첫 아이템 획득 시, 아이템 검증 시작
+  if (!getItemTime) {
+    getItemTime = timestamp;
+    return { status: 'success', message: 'begin item aquire verification' };
+  }
 
   const elapsedTime = (timestamp - getItemTime) / 1000;
 
-  // 아이템에 따른 생성시간과 아이템 실제 획득 시간 출력
-  console.log(`responseTime : ${responseTime}, elapsedTime : ${elapsedTime}`);
-
-  // 아이템 최소 생성 시간(5초)보다 작을 시 아이템 획득 인증 실패
+  // 아이템 최소 생성 시간(5초)보다 아이템 획득 시간이 작을 시, 아이템 획득 인증 실패 메시지 반환
   if (elapsedTime < INTERVAL_MIN) {
-    return { status: 'fail', message: 'item verification failed' };
+    return { status: 'fail', message: 'item aquire verification failed' };
   }
 
   getItemTime = timestamp;
 
-  return { status: 'success', message: 'item verification successfully' };
+  return {
+    status: 'success',
+    message: 'item score & unlock stage & aquire verification successfully',
+  };
 };


### PR DESCRIPTION
### 아이템 별 획득 점수 구분

- 기존 10점씩 스테이지가 변경 된 것을 100점씩 스테이지 변경하는 것으로 원복
- 아이템 테이블의 아이템 별 획득 점수 기반으로 아이템 획득 시 점수 추가
- 아이템 종류 별 획득 점수 검증
- 아이템 종류 별 획득 스테이지 검증

```json
// 아이템 테이블
{
  "name": "item",
  "version": "1.0.0",
  "data": [
    { "id": 1, "score": 10, "responseTime": 11 },
    { "id": 2, "score": 20, "responseTime": 12 },
    { "id": 3, "score": 30, "responseTime": 13 },
    { "id": 4, "score": 40, "responseTime": 14 },
    { "id": 5, "score": 50, "responseTime": 15 },
    { "id": 6, "score": 60, "responseTime": 16 }
  ]
}
```

```json
// 아이템 해금 테이블
{
  "name": "item_unlock",
  "version": "1.0.0",
  "data": [
    { "id": 101, "stage_id": 1001, "item_id": [1] },
    { "id": 201, "stage_id": 1002, "item_id": [1, 2] },
    { "id": 301, "stage_id": 1003, "item_id": [1, 2, 3] },
    { "id": 401, "stage_id": 1004, "item_id": [1, 2, 3, 4] },
    { "id": 501, "stage_id": 1005, "item_id": [1, 2, 3, 4, 5] },
    { "id": 601, "stage_id": 1006, "item_id": [1, 2, 3, 4, 5, 6] }
  ]
}

```

### [ 클라이언트(브라우저) 콘솔창 ] 아이템 별 획득 점수 구분 이미지

![image](https://github.com/eliotjang/websocket-real-time-game/assets/37320831/dbba0ede-ebca-4c6c-8b30-d1fab43bd84e)
